### PR TITLE
Bypass VOL: Fix inconsistent dataset info tracking

### DIFF
--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -4808,6 +4808,11 @@ should_use_native(const dset_t *dset_info, bool *should_use_native) {
         goto done;
     }
 
+    if (dset_info->layout == H5D_COMPACT) {
+        *should_use_native = true;
+        goto done;
+    }
+
     // TBD: Link type?
     *should_use_native = false;
 

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -4797,7 +4797,8 @@ should_use_native(const dset_t *dset_info, bool *should_use_native) {
 
     if (H5T_TIME == dset_info->dtype_class || H5T_OPAQUE == dset_info->dtype_class ||
         H5T_COMPOUND == dset_info->dtype_class || H5T_REFERENCE == dset_info->dtype_class ||
-        H5T_VLEN == dset_info->dtype_class || H5T_ARRAY == dset_info->dtype_class) {
+        H5T_VLEN == dset_info->dtype_class || H5T_ARRAY == dset_info->dtype_class
+        || H5T_STRING == dset_info->dtype_class) {
         *should_use_native = true;
         goto done;
     }

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2565,6 +2565,7 @@ H5VL_bypass_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t 
     Bypass_dataset_t *bypass_dset = NULL;
     sel_info_t selection_info;
     int        i, j;
+    int        num_ext_files     = 0;
     bool       any_thread_active = false;
     bool       read_use_native   = false;
     bool       external_link_access = false;
@@ -2628,11 +2629,17 @@ H5VL_bypass_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t 
             }
         }
 
-        /* If the dataset's file is not in table, it must be have been accessed through
-         * an external link */
-        if (selection_info.my_file_index < 0)
+        if ((num_ext_files = H5Pget_external_count(bypass_dset->dcpl_id)) < 0) {
+            fprintf(stderr, "failed to get external file count\n");
+            ret_value = -1;
+            goto done;
+        }
+
+        /* If the dataset's file is not in table, it was accessed through an external link. */
+        if (selection_info.my_file_index < 0 || num_ext_files > 0)
             external_link_access = true;
     
+
         /* Check selection type */
         if (mem_space_id[j] == H5S_ALL) {
             mem_sel_type = H5S_SEL_ALL;

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2052,9 +2052,15 @@ process_vectors(void *rbuf, sel_info_t *selection_info)
                 goto done;
             }
 
-            nelmts -= seq_nelem;
-            file_seq_i = 0;
+        if (file_nseq == 0) {
+            fprintf(stderr, "no file sequences retrieved from iteration\n");
+            ret_value = -1;
+            goto done;
         }
+
+	    nelmts -= seq_nelem;
+	    file_seq_i = 0;
+	}
 
         /* Fill/refill memory sequence list if necessary */
         if (mem_seq_i == SEL_SEQ_LIST_LEN) {
@@ -2066,8 +2072,14 @@ process_vectors(void *rbuf, sel_info_t *selection_info)
                 goto done;
             }
 
-            mem_seq_i = 0;
+        if (mem_nseq == 0) {
+            fprintf(stderr, "no memory sequences retrieved from iteration\n");
+            ret_value = -1;
+            goto done;
         }
+
+	   mem_seq_i = 0;
+	}
 
         /* Calculate length of this IO */
         io_len = MIN(file_len[file_seq_i], mem_len[mem_seq_i]);

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -1485,7 +1485,7 @@ done:
         if (dset->dcpl_id > 0)
             H5Pclose(dset->dcpl_id);
         if (dset->space_id > 0)
-            H5Pclose(dset->space_id);
+            H5Sclose(dset->space_id);
         } H5E_END_TRY;
     }
 }
@@ -4973,7 +4973,7 @@ release_dset_info(Bypass_dataset_t *dset) {
 
     assert(dset);
 
-    if (dset->dcpl_id > 0 && H5Idec_ref(dset->dcpl_id) < 0) {
+    if (dset->dcpl_id > 0 && H5Pclose(dset->dcpl_id) < 0) {
         fprintf(stderr, "unable to decrement ref count of DCPL\n");
         ret_value = -1;
         goto done;
@@ -4981,7 +4981,7 @@ release_dset_info(Bypass_dataset_t *dset) {
 
     dset->dcpl_id = H5I_INVALID_HID;
 
-    if (dset->space_id > 0 && H5Idec_ref(dset->space_id) < 0) {
+    if (dset->space_id > 0 && H5Sclose(dset->space_id) < 0) {
         fprintf(stderr, "unable to decrement ref count of dataspace\n");
         ret_value = -1;
         goto done;
@@ -4996,9 +4996,9 @@ done:
     if (ret_value < 0) {
         H5E_BEGIN_TRY {
             if (dset->dcpl_id > 0)
-                H5Idec_ref(dset->dcpl_id);
+                H5Pclose(dset->dcpl_id);
             if (dset->space_id > 0)
-                H5Idec_ref(dset->space_id);
+                H5Sclose(dset->space_id);
         } H5E_END_TRY;
     }
 

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -4795,10 +4795,7 @@ should_use_native(const dset_t *dset_info, bool *should_use_native) {
         goto done;
     }
 
-    if (H5T_TIME == dset_info->dtype_class || H5T_OPAQUE == dset_info->dtype_class ||
-        H5T_COMPOUND == dset_info->dtype_class || H5T_REFERENCE == dset_info->dtype_class ||
-        H5T_VLEN == dset_info->dtype_class || H5T_ARRAY == dset_info->dtype_class
-        || H5T_STRING == dset_info->dtype_class) {
+    if (H5T_INTEGER != dset_info->dtype_class && H5T_FLOAT != dset_info->dtype_class) {
         *should_use_native = true;
         goto done;
     }

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -4642,7 +4642,6 @@ get_dset_info(H5VL_bypass_t *dset, dset_t **info_out, hid_t dxpl_id, void** req)
     hid_t dcpl_id = H5I_INVALID_HID;
     H5VL_native_dataset_optional_args_t dset_opt_args;
     H5VL_optional_args_t opt_args;
-    int num_filters = 0;
     H5T_class_t dtype_class;
     dset_t *dset_info = NULL;
 
@@ -4755,7 +4754,7 @@ get_dset_info(H5VL_bypass_t *dset, dset_t **info_out, hid_t dxpl_id, void** req)
     }
 
     /* Retrieve the dataset's number of filters */
-    if ((num_filters = H5Pget_nfilters(dset_info->dcpl_id)) < 0) {
+    if ((dset_info->num_filters = H5Pget_nfilters(dset_info->dcpl_id)) < 0) {
         fprintf(stderr, "unable to get dataset's number of filters\n");
         ret_value = -1;
         goto done;

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2676,7 +2676,8 @@ H5VL_bypass_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t 
 
         read_use_native = dset_use_native || !types_equal || 
             external_link_access || mem_sel_type == H5S_SEL_POINTS || file_sel_type == H5S_SEL_POINTS
-            || dset_space_status != H5D_SPACE_STATUS_ALLOCATED;
+            || dset_space_status != H5D_SPACE_STATUS_ALLOCATED || mem_space_id[j] == H5S_BLOCK
+            || file_space_id[j] == H5S_BLOCK || mem_space_id[j] == H5S_PLIST || file_space_id[j] == H5S_PLIST;
 
         if (read_use_native) {
 

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -69,26 +69,6 @@ static file_t *file_stuff;
 static int file_stuff_count = 0;
 static int file_stuff_size = FILE_STUFF_SIZE;
 
-<<<<<<< HEAD
-/* Dataset info */
-typedef struct {
-<<<<<<< HEAD
-    char dset_name[BYPASS_NAME_SIZE_LONG];
-    char file_name[BYPASS_NAME_SIZE_LONG];
-=======
-    char file_name[1024];
->>>>>>> c9d2673 (Fix multiple opens of same dataset not being recognized)
-    H5D_layout_t layout;
-    hid_t dcpl_id;
-    hid_t dtype_id;
-    hid_t space_id;
-    haddr_t location;
-    int num_filters;
-    H5T_class_t dtype_class;
-} dset_t;
-
-=======
->>>>>>> 1d0fb1c (Rework dataset/datatype handling)
 /* Log info to be written out for the C program */
 typedef struct {
     char    file_name[64];        /* file name to be read or written */

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -69,6 +69,7 @@ static file_t *file_stuff;
 static int file_stuff_count = 0;
 static int file_stuff_size = FILE_STUFF_SIZE;
 
+<<<<<<< HEAD
 /* Dataset info */
 typedef struct {
 <<<<<<< HEAD
@@ -86,6 +87,8 @@ typedef struct {
     H5T_class_t dtype_class;
 } dset_t;
 
+=======
+>>>>>>> 1d0fb1c (Rework dataset/datatype handling)
 /* Log info to be written out for the C program */
 typedef struct {
     char    file_name[64];        /* file name to be read or written */

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -71,20 +71,20 @@ static int file_stuff_size = FILE_STUFF_SIZE;
 
 /* Dataset info */
 typedef struct {
+<<<<<<< HEAD
     char dset_name[BYPASS_NAME_SIZE_LONG];
     char file_name[BYPASS_NAME_SIZE_LONG];
+=======
+    char file_name[1024];
+>>>>>>> c9d2673 (Fix multiple opens of same dataset not being recognized)
     H5D_layout_t layout;
-    unsigned ref_count;     /* Reference count    */
     hid_t dcpl_id;
     hid_t dtype_id;
     hid_t space_id;
     haddr_t location;
-    hbool_t use_native;    /* flag for skipping bypass VOL and use the native functions */
+    int num_filters;
+    H5T_class_t dtype_class;
 } dset_t;
-
-static dset_t *dset_stuff;
-static int dset_count = 0;
-static int dset_info_size = DSET_INFO_SIZE;
 
 /* Log info to be written out for the C program */
 typedef struct {


### PR DESCRIPTION
Datasets don't have a consistent universal name within HDF5, so the Bypass VOL's global dataset info table being indexed by dataset name leads to several problems. One of these was bad object cleanup, which resulted in weak file close operations being delayed indefinitely and library termination falling into an infinite loop. 

This is the root cause of the 'cork' test failing with the Bypass VOL. The cork test creates a file of the same name twice, after closing the first instance. The current implementation fails to clean up all objects in the first file instance, then fails to close it and runs into a conflict with the attempted new creation.

We could theoretically try to use a different index into the dataset table, but I think it makes the most sense to remove it outright and acquire the necessary information locally during reads, which is the approach this PR takes.

Specific changes:

- Remove global dataset info table

Dataset info is now acquired locally at read time. `get_dset_info()` allocates and returns an info struct

- Refactor `remove_dset_info_helper` to now cleanup and release a provided instance of `dset_t`, instead of operating on the dataset info table

- Remove `dset_open_helper`

No longer necessary, since we don't get dataset information at file open time anymore

- Move the checks for whether a dataset should be operated on through the native VOL into a dedicated routine, `should_use_native()`

- Use Native VOL if the target dataset was opened through an external link 

- Add miscellaneous error checks