### PR TITLE
Fix filename check at readtime

### DIFF
--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2170,22 +2170,29 @@ H5VL_bypass_dataset_read(size_t count, void *dset[],
 	    //get_filename_helper((H5VL_bypass_t *)(dset[j]), file_name, H5I_DATASET, req);
 //fprintf(stderr, "%s at %d: file_name = %s\n", __func__, __LINE__, file_name);
 
-	    /* Find the correct data file */
-	    for (i = 0; i < file_stuff_count; i++) {
-		if (!strcmp(file_stuff[i].name, file_name))
-		    selection_info.my_file_index = i;             /* Save this index in the list of FILE_T structures for quick lookup later */
-                else {
-                    printf("In %s of %s at line %d: can't find the file with the name %s\n", __func__, __FILE__, __LINE__, file_name);
-                    ret_value = -1;
-                    goto done;
+            /* Find the correct data file */
+            selection_info.my_file_index = -1;
+            
+            for (i = 0; i < file_stuff_count; i++) {
+                if (!strcmp(file_stuff[i].name, file_name)) {
+                    selection_info.my_file_index =
+                        i; /* Save this index in the list of FILE_T structures for quick lookup later */
+                    break;
                 }
             }
 
-	    /* Initialize data selection info */
-	    strcpy(selection_info.file_name, file_name);
-	    strcpy(selection_info.dset_name, dset_name);
+            if (selection_info.my_file_index < 0) {
+                printf("In %s of %s at line %d: can't find the file with the name %s\n", __func__, __FILE__,
+                __LINE__, file_name);
+                ret_value = -1;
+                goto done;
+            }
 
-	    selection_info.dtype_size = H5Tget_size(dset_dtype_id);
+            /* Initialize data selection info */
+            strcpy(selection_info.file_name, file_name);
+	        strcpy(selection_info.dset_name, dset_name);
+
+	        selection_info.dtype_size = H5Tget_size(dset_dtype_id);
 
 	    if (H5D_CHUNKED == dset_layout) {
 		/* Iterate through all chunks and map the data selection in each chunk to the memory.

--- a/vol_bypass/test/h5_create.c
+++ b/vol_bypass/test/h5_create.c
@@ -96,8 +96,10 @@ int create_files()
         else
             sprintf(file_name, "%s%d.h5", FILE_NAME, k + 1);
 
-        file = H5Fcreate(file_name, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-
+        if ((file = H5Fcreate(file_name, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+            fprintf(stderr, "Cannot create file %s\n", file_name);
+            return -1;
+        }
         /* Create and writes data to dataset(s) */
         for (n = 0; n < hand.num_dsets; n++) {
             if (hand.num_dsets == 1)

--- a/vol_bypass/test/run_multi_dsets.sh
+++ b/vol_bypass/test/run_multi_dsets.sh
@@ -10,8 +10,8 @@ DIM2=4
 NDSETS=4
 
 # Make sure these two environment variables aren't set in order to run the test without Bypass VOL
-unset HDF5_VOL_CONNECTOR
-unset HDF5_PLUGIN_PATH
+#unset HDF5_VOL_CONNECTOR
+#unset HDF5_PLUGIN_PATH
 
 echo "Test 0: Creating a HDF5 file with multiple datasets in it"
 ./h5_create -d ${DIM1}x${DIM2} -n ${NDSETS}
@@ -21,11 +21,11 @@ echo "Test 1: Reading multiple datasets in a single file with straight HDF5 (no 
 ./h5_read -t 0 -d ${DIM1}x${DIM2} -n ${NDSETS} -k
 
 # Set the environment variables to use Bypass VOL. Need to modify them with your own paths 
-export HDF5_PLUGIN_PATH=/Users/raylu/Lifeboat/HDF/MT-HDF5/vol_bypass
-export HDF5_VOL_CONNECTOR="bypass under_vol=0;under_info={};"
-export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/raylu/Lifeboat/HDF/Experimental/build/hdf5/lib:$HDF5_PLUGIN_PATH
-export BYPASS_VOL_NTHREADS=${NTHREADS}
-export BYPASS_VOL_NSTEPS=${NSTEPS_QUEUE}
+#export HDF5_PLUGIN_PATH=/Users/raylu/Lifeboat/HDF/MT-HDF5/vol_bypass
+#export HDF5_VOL_CONNECTOR="bypass under_vol=0;under_info={};"
+#export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/raylu/Lifeboat/HDF/Experimental/build/hdf5/lib:$HDF5_PLUGIN_PATH
+#export BYPASS_VOL_NTHREADS=${NTHREADS}
+#export BYPASS_VOL_NSTEPS=${NSTEPS_QUEUE}
 
 echo ""
 echo "Test 2a: Reading multiple datasets in a single file with Bypass VOL"
@@ -37,9 +37,9 @@ echo "Test 2b: Reading multiple datasets in a single file using H5Dread_multi wi
 
 # Disabled this test as the work is still ongoing
 # The C test must follow the test with Bypass VOL immediately to use info.log file which contains file name and data info
-# echo ""
-# echo "Test 3: Reading multiple datasets in a single file in C only"
-# ./posix_read -t ${NTHREADS} -d ${DIM1}x${DIM2} -n ${NDSETS} -k
+echo ""
+echo "Test 3: Reading multiple datasets in a single file in C only"
+./posix_read -t ${NTHREADS} -d ${DIM1}x${DIM2} -n ${NDSETS} -k
 
 # Avoid checking the correctness of the data if there are more than one section because the thread pool may still be 
 # reading the data during the check.  Each section corresponds to a H5Dread.  Sections are seperated by ### in info.log.

--- a/vol_bypass/test/run_multi_files.sh
+++ b/vol_bypass/test/run_multi_files.sh
@@ -12,8 +12,8 @@ DIM2=16
 NFILES=4
 
 # Make sure these two environment variables aren't set in order to run the test without Bypass VOL
-unset HDF5_VOL_CONNECTOR
-unset HDF5_PLUGIN_PATH
+#unset HDF5_VOL_CONNECTOR
+#unset HDF5_PLUGIN_PATH
 
 echo "Test 0: Creating multiple HDF5 files with a single dataset in each of them"
 ./h5_create -d ${DIM1}x${DIM2} -f ${NFILES}
@@ -23,11 +23,11 @@ echo "Test 1: Reading single dataset in a single file with straight HDF5 (no Byp
 ./h5_read -t 0 -d ${DIM1}x${DIM2} -f ${NFILES} -k
 
 # Set the environment variables to use Bypass VOL. Need to modify them with your own paths 
-export HDF5_PLUGIN_PATH=/Users/raylu/Lifeboat/HDF/MT-HDF5/vol_bypass
-export HDF5_VOL_CONNECTOR="bypass under_vol=0;under_info={};"
-export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/raylu/Lifeboat/HDF/Experimental/build/hdf5/lib:$HDF5_PLUGIN_PATH
-export BYPASS_VOL_NTHREADS=${NTHREADS}
-export BYPASS_VOL_NSTEPS=${NSTEPS_QUEUE}
+#export HDF5_PLUGIN_PATH=/Users/raylu/Lifeboat/HDF/MT-HDF5/vol_bypass
+#export HDF5_VOL_CONNECTOR="bypass under_vol=0;under_info={};"
+#export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/raylu/Lifeboat/HDF/Experimental/build/hdf5/lib:$HDF5_PLUGIN_PATH
+#export BYPASS_VOL_NTHREADS=${NTHREADS}
+#export BYPASS_VOL_NSTEPS=${NSTEPS_QUEUE}
 
 echo ""
 echo "Test 2a: Reading single dataset in multiple files with Bypass VOL"
@@ -45,6 +45,6 @@ echo "Test 2b: Reading single dataset in multiple files using H5Dread_multi with
 # Avoid checking the correctness of the data if there are more than one section because the thread pool may still be 
 # reading the data during the check.  Each section corresponds to a H5Dread.  Sections are seperated by ### in info.log.
 # The way thread pool is set up doesn't guarantee the data reading is finished during the check.
-echo ""
-echo "Test 3c: Reading single dataset in a single file in C only with thread pool"
-./posix_read_tpool -t ${NTHREADS} -d ${DIM1}x${DIM2} -f ${NFILES} -k
+#echo ""
+#echo "Test 3c: Reading single dataset in a single file in C only with thread pool"
+#./posix_read_tpool -t ${NTHREADS} -d ${DIM1}x${DIM2} -f ${NFILES} -k


### PR DESCRIPTION
The current loop will throw an error if the first checked entry does not match the file that is being searched for, preventing the rest of the file table from being searched.