### PR TITLE
Bypass VOL - Add missing locks around global resources

### DIFF
--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2001,10 +2001,12 @@ start_thread_for_pool(void *args)
 
             file_stuff[file_indices_local[i]].num_reads--;
 
-            /* When there is no task left in the queue and all the reads finish for
-             * the current file, signal the main process that this file can be closed.
-             */
-            if (thread_loop_finish && (file_stuff[file_indices_local[i]].num_reads == 0)) {
+            /* If the active read count for this file has dropped to zero, close it.
+             * TBD - Certain access patterns may lead to the same file being opened/closed many times.
+             * However, it was necessary to remove the thread_loop_finish check here
+             * in order to prevent a scenario where a busy queue prevents the file from
+             * being released entirely. */
+            if (file_stuff[local_tasks[i].file_index].num_reads == 0) {
                 // fprintf(stderr, "thread %d: file name = %s, signal close_ready\n", thread_id,
                 // file_stuff[file_indices_local[i]].name);
                 /* There are currently no reads active on this file - it may be closed */

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -1897,7 +1897,6 @@ start_thread_for_pool(void *args)
     void   **vec_bufs_local = NULL;
     int      local_count = 0;
     int      i;
-
     // fprintf(stderr, "In start_thread_for_pool: %d\n", thread_id);
 
     if ((file_indices_local = (int *)malloc(nsteps_tpool * sizeof(int))) == NULL) {
@@ -1958,7 +1957,6 @@ start_thread_for_pool(void *args)
             thread_task_count--;
 
             file_stuff[file_indices_local[i]].num_reads++;
-            file_stuff[file_indices_local[i]].read_started = true;
         }
 
         // fprintf(stderr, "thread %d: 1. local_count = %d, thread_task_count = %d,
@@ -1999,18 +1997,21 @@ start_thread_for_pool(void *args)
                 goto done;
             }
 
+            /* Read count should still be at least one at this point */
+            if (file_stuff[file_indices_local[i]].num_reads == 0) {
+                fprintf(stderr, "invalid number of reads for file %s\n", file_stuff[file_indices_local[i]].name);
+                ret_value = (void *)-1;
+                goto done;
+            }
+
             file_stuff[file_indices_local[i]].num_reads--;
 
-            /* If the active read count for this file has dropped to zero, close it.
-             * TBD - Certain access patterns may lead to the same file being opened/closed many times.
-             * However, it was necessary to remove the thread_loop_finish check here
-             * in order to prevent a scenario where a busy queue prevents the file from
-             * being released entirely. */
-            if (file_stuff[local_tasks[i].file_index].num_reads == 0) {
+            /* If the active read count for this file has dropped to zero,
+             * allow any concurrent requests to close that file to proceed */
+            if (file_stuff[file_indices_local[i]].num_reads == 0) {
                 // fprintf(stderr, "thread %d: file name = %s, signal close_ready\n", thread_id,
                 // file_stuff[file_indices_local[i]].name);
                 /* There are currently no reads active on this file - it may be closed */
-                file_stuff[file_indices_local[i]].read_started = false;
                 pthread_cond_signal(&(file_stuff[file_indices_local[i]].close_ready));
             }
 
@@ -3336,6 +3337,21 @@ c_file_open_helper(const char *name)
         goto done;
     }
 
+    /* Increment the reference count for this file */
+    file_stuff[file_stuff_count].ref_count++;
+
+    strcpy(file_stuff[file_stuff_count].name, name);
+
+    file_stuff[file_stuff_count].num_reads    = 0;
+    pthread_cond_init(&(file_stuff[file_stuff_count].close_ready),
+                      NULL); /* Initialize the condition variable for file closing */
+    /*printf("%s: name = %s, file_stuff_count = %d, file_stuff[%d].name = %s, file_stuff[%d].fp = %d\n",
+     * __func__, name, file_stuff_count, file_stuff_count, file_stuff[file_stuff_count].name,
+     * file_stuff_count, file_stuff[file_stuff_count].fp);*/
+
+    /* Increment the number of files being opened with C */
+    file_stuff_count++;
+
 done:
     if (ret_value == 0) {
         /* Success */
@@ -3817,7 +3833,6 @@ remove_file_info_helper(unsigned index)
             /* file_stuff[i].vfd_file_handle = file_stuff[i + 1].vfd_file_handle; */
             file_stuff[i].ref_count    = file_stuff[i + 1].ref_count;
             file_stuff[i].num_reads    = file_stuff[i + 1].num_reads;
-            file_stuff[i].read_started = file_stuff[i + 1].read_started;
             file_stuff[i].close_ready  = file_stuff[i + 1].close_ready;
         }
 
@@ -3878,24 +3893,9 @@ H5VL_bypass_file_close(void *file, hid_t dxpl_id, void **req)
     for (i = 0; i < file_stuff_count; i++) {
         pthread_mutex_lock(&mutex_local);
         if (!strcmp(file_stuff[i].name, file_name) && file_stuff[i].fd) {
-            // fprintf(stderr, "%s at %d: file_name = %s, i = %d, file_stuff_count =
-            // %d, file_stuff[i].ref_count = %d, file_stuff[i].read_started = %d,
-            // num_reads = %d\n", __func__,
-            // __LINE__, file_name, i, file_stuff_count, file_stuff[i].ref_count,
-            // file_stuff[i].read_started, file_stuff[i].num_reads);
-            /* Wait until all thread in the thread pool finish reading the data before
-             * closing the C file */
-            if (file_stuff[i].read_started) {
-                // while (!file_stuff[i].read_started || file_stuff[i].num_reads)
-                while (file_stuff[i].num_reads)
-                    pthread_cond_wait(&(file_stuff[i].close_ready), &mutex_local);
-            }
-
-            // fprintf(stderr, "%s at %d: file_name = %s, i = %d, file_stuff_count =
-            // %d, file_stuff[i].ref_count = %d, file_stuff[i].read_started = %d,
-            // num_reads = %d\n", __func__,
-            // __LINE__, file_name, i, file_stuff_count, file_stuff[i].ref_count,
-            // file_stuff[i].read_started, file_stuff[i].num_reads);
+            /* Wait until all thread in the thread pool finish reading the data before closing the C file */
+            while (file_stuff[i].num_reads > 0)
+                pthread_cond_wait(&(file_stuff[i].close_ready), &mutex_local);
 
             file_stuff[i].ref_count--;
 

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -60,8 +60,7 @@ typedef struct {
     int  fd;                /* C file descriptor  */ 
     /* void *vfd_file_handle;  Currently not used */
     unsigned ref_count;     /* Reference count    */
-    int  num_reads;         /* Number of reads still left undone */
-    bool read_started;      /* Flag to indicate reads have started */
+    size_t  num_reads;         /* Number of reads still left undone */
     pthread_cond_t close_ready;    /* Condition variable to indicate all reads are finished and the file can be close */ 
 } file_t;
 


### PR DESCRIPTION
- Simplify file close handling (remove read_started, since its truth value should always be equivalent to `num_reads > 0`) to avoid a file potentially being left open
- Add missing lock/unlock calls around global resources