### PR TITLE
Bypass VOL: Rework task queue

### DIFF
--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -277,6 +277,10 @@ static herr_t get_dtype_info_helper(hid_t type_id, dtype_info_t *type_info_out);
 static H5D_space_status_t
 get_dset_space_status(H5VL_bypass_t *dset_obj, hid_t dxpl_id, void **req);
 
+static herr_t bypass_queue_destroy(void);
+static herr_t bypass_queue_push(Bypass_task_t *task);
+static Bypass_task_t *bypass_queue_pop(void);
+static Bypass_task_t * bypass_task_create(int file_index, haddr_t addr, size_t io_len, void *buf);
 /*******************/
 /* Local variables */
 /*******************/
@@ -587,15 +591,9 @@ H5VL_bypass_init(hid_t vipl_id)
     // printf("%s at line %d: nthreads_tpool = %d, nsteps_tpool = %d\n", __func__,
     // __LINE__, nthreads_tpool, nsteps_tpool);
 
-    /* Initialize the information strcuture for threads to use.  Do it before
-     * starting threads */
-    md_for_thread.file_indices   = md_for_thread.file_indices_local;
-    md_for_thread.addrs          = md_for_thread.addrs_local;
-    md_for_thread.sizes          = md_for_thread.sizes_local;
-    md_for_thread.vec_bufs       = md_for_thread.vec_bufs_local;
-    md_for_thread.vec_arr_nalloc = LOCAL_VECTOR_LEN;
-    md_for_thread.vec_arr_nused  = 0;
-    md_for_thread.free_memory    = false;
+    /* Initialize the task queue */
+    bypass_queue_head_g = NULL;
+    bypass_queue_tail_g = NULL;
 
     /* Initialize thread active status to true */
     md_for_thread.thread_is_active = calloc(nthreads_tpool, sizeof(bool));
@@ -646,6 +644,8 @@ H5VL_bypass_term(void)
     FILE *log_fp;
     int   i;
     void  *thread_ret = NULL;
+    bool  any_thread_active = false;
+    herr_t ret_value = 0;
 
 #ifdef ENABLE_BYPASS_LOGGING
     printf("------- BYPASS  VOL TERM\n");
@@ -672,11 +672,6 @@ H5VL_bypass_term(void)
             fprintf(stderr, "thread %d failed\n", i);
         }
     }
-
-    pthread_mutex_destroy(&mutex_local);
-    pthread_cond_destroy(&cond_local);
-    pthread_cond_destroy(&cond_read_finished);
-    pthread_cond_destroy(&continue_local);
 
     /* Open the log file and output the following info:
      * - file name
@@ -706,6 +701,29 @@ H5VL_bypass_term(void)
 
     fclose(log_fp);
 
+    // printf("%s: %d, dset_count = %d, dset_stuff[0].space_id = %lld\n",
+    // __func__, __LINE__, dset_count, dset_stuff[0].space_id);
+
+
+    /* Wait until all threads finish before releasing the queue */
+    pthread_mutex_lock(&mutex_local);
+
+    while (true) {
+        if (is_any_thread_active(&any_thread_active) < 0) {
+            fprintf(stderr, "error while checking thread active status for vol termination\n");
+            ret_value = -1;
+            break;
+        }
+        
+        if (!any_thread_active)
+            break;
+        
+    }
+
+    pthread_mutex_unlock(&mutex_local);
+
+    bypass_queue_destroy();
+
     if (file_stuff)
         free(file_stuff);
     if (info_stuff)
@@ -715,19 +733,12 @@ H5VL_bypass_term(void)
     if (md_for_thread.thread_is_active)
         free(md_for_thread.thread_is_active);
 
-    /* Wait until all threads finish before releasing resources */
-    if (md_for_thread.free_memory) {
-        if (md_for_thread.file_indices)
-            free(md_for_thread.file_indices);
-        if (md_for_thread.addrs)
-            free(md_for_thread.addrs);
-        if (md_for_thread.sizes)
-            free(md_for_thread.sizes);
-        if (md_for_thread.vec_bufs)
-            free(md_for_thread.vec_bufs);
-    }
+    pthread_mutex_destroy(&mutex_local);
+    pthread_cond_destroy(&cond_local);
+    pthread_cond_destroy(&cond_read_finished);
+    pthread_cond_destroy(&continue_local);
 
-    return 0;
+    return ret_value;
 } /* end H5VL_bypass_term() */
 
 /*---------------------------------------------------------------------------
@@ -1890,38 +1901,18 @@ start_thread_for_pool(void *args)
     int thread_id = ((info_for_thread_t *)args)->thread_id;
     // int fd = ((info_for_thread_t *)args)->fd;
     void    *ret_value = (void*) 0;
-    int     *file_indices_local = NULL;
-    haddr_t *addrs_local = NULL;
-    size_t  *sizes_local = NULL;
-    void   **vec_bufs_local = NULL;
+    Bypass_task_t **tasks = NULL;
     int      local_count = 0;
     int      i;
 
     // fprintf(stderr, "In start_thread_for_pool: %d\n", thread_id);
 
-    if ((file_indices_local = (int *)malloc(nsteps_tpool * sizeof(int))) == NULL) {
-        fprintf(stderr, "failed to allocate file indices\n");
-        ret_value = (void*) -1;
-        goto done;
-    }
-    
-    if ((addrs_local = (haddr_t *)malloc(nsteps_tpool * sizeof(haddr_t))) == NULL) {
-        fprintf(stderr, "failed to allocate addresses\n");
-        ret_value = (void*) -1;
-        goto done;
-    }
-
-    if ((sizes_local = (size_t *)malloc(nsteps_tpool * sizeof(size_t))) == NULL) {
-        fprintf(stderr, "failed to allocate sizes\n");
-        ret_value = (void*) -1;
-        goto done;
-    }
-
-    if ((vec_bufs_local = (void *)malloc(nsteps_tpool * sizeof(void *))) == NULL) {
+    if ((tasks = (Bypass_task_t **)malloc(nsteps_tpool * sizeof(Bypass_task_t*))) == NULL) {
         fprintf(stderr, "failed to allocate vector buffers\n");
         ret_value = (void*) -1;
         goto done;
     }
+
     /* Rename thread_loop_finish to a more appropriate name */
     while (!thread_loop_finish || !stop_tpool) {
         if (pthread_mutex_lock(&mutex_local) != 0) {
@@ -1948,16 +1939,17 @@ start_thread_for_pool(void *args)
         local_count = MIN(thread_task_count, nsteps_tpool);
 
         for (i = 0; i < local_count; i++) {
-            file_indices_local[i] = md_for_thread.file_indices[info_pointer];
-            addrs_local[i]        = md_for_thread.addrs[info_pointer];
-            sizes_local[i]        = md_for_thread.sizes[info_pointer];
-            vec_bufs_local[i]     = md_for_thread.vec_bufs[info_pointer];
+            /* Get first task in queue */
+            if ((tasks[i] = bypass_queue_pop()) == NULL) {
+                fprintf(stderr, "failed to pop task from queue\n");
+                ret_value = (void*) -1;
+                goto done;
+            }
 
-            info_pointer++;
-            thread_task_count--;
+            // info_pointer++;
 
-            file_stuff[file_indices_local[i]].num_reads++;
-            file_stuff[file_indices_local[i]].read_started = true;
+            file_stuff[tasks[i]->file_index].num_reads++;
+            file_stuff[tasks[i]->file_index].read_started = true;
         }
 
         // fprintf(stderr, "thread %d: 1. local_count = %d, thread_task_count = %d,
@@ -1983,8 +1975,8 @@ start_thread_for_pool(void *args)
             // sizes_local = %ld, addrs_local = %llu\n", thread_id, i, file_indices_local[i],
             // vec_bufs_local[i], sizes_local[i], addrs_local[i]);
 
-            if (read_big_data(file_stuff[file_indices_local[i]].fd, vec_bufs_local[i], sizes_local[i],
-                          addrs_local[i]) < 0)
+            if (read_big_data(file_stuff[tasks[i]->file_index].fd, tasks[i]->vec_buf, tasks[i]->size,
+                          tasks[i]->addr) < 0)
             {
                 fprintf(stderr, "read_big_data failed within file %s\n", file_stuff[file_indices_local[i]].name);
                 /* Return a failure code, but try to complete the rest of the read request.
@@ -1998,17 +1990,17 @@ start_thread_for_pool(void *args)
                 goto done;
             }
 
-            file_stuff[file_indices_local[i]].num_reads--;
+            file_stuff[tasks[i]->file_index].num_reads--;
 
             /* When there is no task left in the queue and all the reads finish for
              * the current file, signal the main process that this file can be closed.
              */
-            if (thread_loop_finish && (file_stuff[file_indices_local[i]].num_reads == 0)) {
+            if (thread_loop_finish && (file_stuff[tasks[i]->file_index].num_reads == 0)) {
                 // fprintf(stderr, "thread %d: file name = %s, signal close_ready\n", thread_id,
                 // file_stuff[file_indices_local[i]].name);
                 /* There are currently no reads active on this file - it may be closed */
-                file_stuff[file_indices_local[i]].read_started = false;
-                pthread_cond_signal(&(file_stuff[file_indices_local[i]].close_ready));
+                file_stuff[tasks[i]->file_index].read_started = false;
+                pthread_cond_signal(&(file_stuff[tasks[i]->file_index].close_ready));
             }
 
             if (pthread_mutex_unlock(&mutex_local) != 0) {
@@ -2060,10 +2052,7 @@ done:
         fprintf(stderr, "thread idx %d in pool failed\n", thread_id);
     }
 
-    free(file_indices_local);
-    free(addrs_local);
-    free(sizes_local);
-    free(vec_bufs_local);
+    free(tasks);
 
     return ret_value;
 } /* end start_thread_for_pool() */
@@ -2071,16 +2060,19 @@ done:
 static herr_t
 process_vectors(void *rbuf, sel_info_t *selection_info)
 {
-    hid_t      file_iter_id, mem_iter_id;
-    size_t     file_seq_i, mem_seq_i, file_nseq, mem_nseq;
-    hssize_t   hss_nelmts;
-    size_t     nelmts; 
-    size_t     seq_nelem;
-    hsize_t    file_off[SEL_SEQ_LIST_LEN], mem_off[SEL_SEQ_LIST_LEN];
-    size_t     file_len[SEL_SEQ_LIST_LEN], mem_len[SEL_SEQ_LIST_LEN];
-    size_t     io_len;
-    int        local_count_for_signal = 0;
-    herr_t     ret_value = 0;
+    hid_t    file_iter_id, mem_iter_id;
+    size_t   file_seq_i, mem_seq_i, file_nseq, mem_nseq;
+    hssize_t hss_nelmts;
+    size_t   nelmts;
+    size_t   seq_nelem;
+    hsize_t  file_off[SEL_SEQ_LIST_LEN], mem_off[SEL_SEQ_LIST_LEN];
+    size_t   file_len[SEL_SEQ_LIST_LEN], mem_len[SEL_SEQ_LIST_LEN];
+    size_t   io_len;
+    int      local_count_for_signal = 0;
+    herr_t   ret_value = 0;
+    Bypass_task_t *task = NULL;
+    haddr_t task_addr   = HADDR_UNDEF;
+    void   *task_buf    = NULL;
 
     /* Contiguous is treated as a single chunk */
     if ((hss_nelmts = H5Sget_select_npoints(selection_info->file_space_id)) < 0) {
@@ -2178,124 +2170,35 @@ process_vectors(void *rbuf, sel_info_t *selection_info)
          * datasets. To do: needs a flag to turn it on and off */
         io_len = MIN(io_len, MB);
 
-        /* Lock md_for_thread and update it */
+        /* Lock in order to append to queue */
         if (pthread_mutex_lock(&mutex_local) != 0) {
             fprintf(stderr, "failed to lock local mutex\n");
             ret_value = -1;
             goto done;
         }
 
-        if (md_for_thread.vec_arr_nused == md_for_thread.vec_arr_nalloc) {
-            /* Check if we're using the static arrays */
-            if (md_for_thread.addrs == md_for_thread.addrs_local) {
-                /* Allocate dynamic arrays.  Need to free them later */
-                if (NULL ==
-                    (md_for_thread.file_indices = malloc(sizeof(md_for_thread.file_indices_local) * 2)))
-                {
-                    fprintf(stderr, "memory allocation failed for file ids list\n");
-                    ret_value = -1;
-                    goto done;
-                }
-
-                if (NULL == (md_for_thread.addrs = malloc(sizeof(md_for_thread.addrs_local) * 2)))
-                {
-                    fprintf(stderr, "memory allocation failed for address list\n");
-                    ret_value = -1;
-                    goto done;
-                }
-
-                if (NULL == (md_for_thread.sizes = malloc(sizeof(md_for_thread.sizes_local) * 2)))
-                {
-                    fprintf(stderr, "memory allocation failed for size list\n");
-                    ret_value = -1;
-                    goto done;
-                }
-
-                if (NULL == (md_for_thread.vec_bufs = malloc(sizeof(md_for_thread.vec_bufs_local) * 2)))
-                {
-                    fprintf(stderr, "memory allocation failed for buffer list\n");
-                    ret_value = -1;
-                    goto done;
-                }
-
-                /* Copy the existing data */
-                (void)memcpy(md_for_thread.file_indices, md_for_thread.file_indices_local,
-                             sizeof(md_for_thread.file_indices_local));
-                (void)memcpy(md_for_thread.addrs, md_for_thread.addrs_local,
-                             sizeof(md_for_thread.addrs_local));
-                (void)memcpy(md_for_thread.sizes, md_for_thread.sizes_local,
-                             sizeof(md_for_thread.sizes_local));
-                (void)memcpy(md_for_thread.vec_bufs, md_for_thread.vec_bufs_local,
-                             sizeof(md_for_thread.vec_bufs_local));
-            }
-            else {
-                void *tmp_ptr;
-
-                /* Reallocate arrays */
-                if (NULL == (tmp_ptr = realloc(md_for_thread.file_indices,
-                                               md_for_thread.vec_arr_nalloc *
-                                                   sizeof(*(md_for_thread.file_indices)) * 2)))
-                {
-                    fprintf(stderr, "memory reallocation failed for file ids list\n");
-                    ret_value = -1;
-                    goto done;
-                }
-
-                md_for_thread.file_indices = tmp_ptr;
-                if (NULL == (tmp_ptr = realloc(md_for_thread.addrs, md_for_thread.vec_arr_nalloc *
-                                                                        sizeof(*(md_for_thread.addrs)) * 2)))
-                {
-                    fprintf(stderr, "memory reallocation failed for address list\n");
-                    ret_value = -1;
-                    goto done;
-                }                                                                    
-
-                md_for_thread.addrs = tmp_ptr;
-                if (NULL == (tmp_ptr = realloc(md_for_thread.sizes, md_for_thread.vec_arr_nalloc *
-                                                                        sizeof(*(md_for_thread.sizes)) * 2)))
-                {
-                    fprintf(stderr, "memory reallocation failed for size list\n");
-                    ret_value = -1;
-                    goto done;
-                }
-
-                md_for_thread.sizes = tmp_ptr;
-                if (NULL ==
-                    (tmp_ptr = realloc(md_for_thread.vec_bufs,
-                                       md_for_thread.vec_arr_nalloc * sizeof(*(md_for_thread.vec_bufs)) * 2)))
-                {
-                    fprintf(stderr, "memory reallocation failed for buffer list\n");
-                    ret_value = -1;
-                    goto done;
-                }
-
-                md_for_thread.vec_bufs = tmp_ptr;
-            }
-
-            /* Record that we've doubled the array sizes */
-            md_for_thread.vec_arr_nalloc *= 2;
-
-            md_for_thread.free_memory = true;
+        if ((task = malloc(sizeof(Bypass_task_t))) == NULL) {
+            fprintf(stderr, "Failed to allocate memory for a task\n");
+            ret_value = -1;
+            goto done;
         }
 
-        /* Add this segment to vector read list */
-        md_for_thread.file_indices[md_for_thread.vec_arr_nused] = selection_info->my_file_index;
-        md_for_thread.addrs[md_for_thread.vec_arr_nused] =
-            selection_info->chunk_addr + file_off[file_seq_i]; /* Add the base offset of the dataset to the
-                                                                  address */
-        md_for_thread.sizes[md_for_thread.vec_arr_nused]    = io_len;
-        md_for_thread.vec_bufs[md_for_thread.vec_arr_nused] = (void *)((uint8_t *)rbuf + mem_off[mem_seq_i]);
+        /* Populate task and append to queue */
+        task_addr = selection_info->chunk_addr + file_off[file_seq_i];
+        task_buf = (void *)((uint8_t *)rbuf + mem_off[mem_seq_i]);
 
-        // fprintf(stderr, "In process_vector: %d. addr = %llu, sizes = %llu, buf =
-        // %p\n", md_for_thread.vec_arr_nused,
-        // md_for_thread.addrs[md_for_thread.vec_arr_nused],
-        // md_for_thread.sizes[md_for_thread.vec_arr_nused],
-        // md_for_thread.vec_bufs[md_for_thread.vec_arr_nused]);
+        if ((task = bypass_task_create(selection_info->my_file_index,
+                        task_addr, io_len, task_buf)) == NULL) {
+            fprintf(stderr, "Failed to assemble task while processing vectors\n");
+            ret_value = -1;
+            goto done;
+        }
 
-        md_for_thread.vec_arr_nused++;
-
-        /* Increment the task in the queue of the thread pool */
-        thread_task_count++;
+        if (bypass_queue_push(task) < 0) {
+            fprintf(stderr, "Failed to push task to queue\n");
+            ret_value = -1;
+            goto done;
+        }
 
         local_count_for_signal++;
 
@@ -5070,7 +4973,7 @@ get_dtype_info(H5VL_bypass_t *dset_obj, hid_t dxpl_id, void **req) {
         goto done;
     }
 
-    if (get_args.args.get_type.type_id < 0) {
+if (get_args.args.get_type.type_id < 0) {
         fprintf(stderr, "retrieved datatype is invalid\n");
         ret_value = -1;
         goto done;
@@ -5183,6 +5086,154 @@ flush_containing_file(H5VL_bypass_t *dset) {
         goto done;
     }
 
+done:
+    return ret_value;
+}
+
+static herr_t
+bypass_queue_destroy(void) {
+    herr_t ret_value = 0;
+    bool locked = false;
+    Bypass_task_t *curr = NULL;
+    Bypass_task_t *next = NULL;
+
+    if (pthread_mutex_lock(&mutex_local) != 0) {
+        fprintf(stderr, "pthread_mutex_lock failed\n");
+        ret_value = -1;
+        goto done;
+    }
+
+    locked = true;
+
+    if (bypass_queue_head_g == NULL) {
+        assert(bypass_queue_tail_g == NULL);
+        assert(thread_task_count == 0);
+        goto done;
+    }
+
+    curr = bypass_queue_head_g;
+
+    while (curr != NULL) {
+        next = curr->next;
+        free(curr);
+        curr = next;
+    }
+
+    bypass_queue_head_g = NULL;
+    bypass_queue_tail_g = NULL;
+    thread_task_count = 0;
+
+done:
+    if (locked && pthread_mutex_unlock(&mutex_local) != 0) {
+        fprintf(stderr, "pthread_mutex_unlock failed\n");
+        ret_value = -1;
+    }
+}
+
+    
+
+static herr_t
+bypass_queue_push(Bypass_task_t *task) {
+    herr_t ret_value = 0;
+    bool locked = false;
+
+    if (pthread_mutex_lock(&mutex_local) != 0) {
+        fprintf(stderr, "pthread_mutex_lock failed\n");
+        ret_value = -1;
+        goto done;
+    }
+
+    locked = true;
+
+    if (bypass_queue_head_g == NULL) {
+        /* Queue is empty */
+        assert(bypass_queue_tail_g == NULL);
+        assert(thread_task_count == 0);
+
+        bypass_queue_head_g = task;
+        bypass_queue_tail_g = task;
+        thread_task_count = 1;
+    } else {
+        assert(bypass_queue_tail_g != NULL);
+        assert(thread_task_count > 0);
+
+        bypass_queue_tail_g->next = task;
+        bypass_queue_tail_g = task;
+        thread_task_count++;
+
+        assert(bypass_queue_head_g != bypass_queue_tail_g);
+    }
+
+done:
+    if (locked && pthread_mutex_unlock(&mutex_local) != 0) {
+        fprintf(stderr, "pthread_mutex_unlock failed\n");
+        ret_value = -1;
+    }
+
+    return ret_value;
+}
+
+static Bypass_task_t *
+bypass_queue_pop(void) {
+    Bypass_task_t *ret_value = NULL;
+    bool locked = false;
+
+    if (pthread_mutex_lock(&mutex_local) != 0) {
+        fprintf(stderr, "pthread_mutex_lock failed\n");
+        goto done;
+    }
+
+    locked = true;
+    
+    /* Queue is empty */
+    if (bypass_queue_head_g == NULL) {
+        assert(bypass_queue_tail_g == NULL);
+        assert(thread_task_count == 0);
+        ret_value = NULL;
+    } else if (bypass_queue_head_g == bypass_queue_tail_g) {
+        /* Queue has only one element */
+        assert(thread_task_count == 1);
+        ret_value = bypass_queue_head_g;
+
+        bypass_queue_head_g = NULL;
+        bypass_queue_tail_g = NULL;
+        thread_task_count = 0;
+    } else {
+        /* Queue has >= 2 elements */
+        assert(thread_task_count > 1);
+        assert(bypass_queue_head_g->next != NULL);
+
+        ret_value = bypass_queue_head_g;
+
+        bypass_queue_head_g = bypass_queue_head_g->next;
+        thread_task_count--;
+    }
+
+done:
+    if (locked && pthread_mutex_unlock(&mutex_local) != 0) {
+        fprintf(stderr, "pthread_mutex_unlock failed\n");
+        ret_value = NULL;
+    }
+
+    return ret_value;
+}
+
+static Bypass_task_t *
+bypass_task_create(int file_index, haddr_t addr, size_t size, void *buf) {
+    Bypass_task_t *ret_value = NULL;
+    
+    if ((ret_value = (Bypass_task_t *)malloc(sizeof(Bypass_task_t))) == NULL) {
+        fprintf(stderr, "failed to allocate space for new read task\n");
+        goto done;
+    }
+
+    ret_value->file_index = file_index;
+    ret_value->addr = addr;
+    ret_value->size = size;
+    ret_value->vec_buf = buf;
+
+    /* Will be populated after this task is inserted into queue */
+    ret_value->next = NULL;
 done:
     return ret_value;
 }

--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2052,6 +2052,10 @@ done:
         fprintf(stderr, "thread idx %d in pool failed\n", thread_id);
     }
 
+    pthread_mutex_lock(&mutex_local);
+    md_for_thread.thread_is_active[thread_id] = false;
+    pthread_mutex_unlock(&mutex_local);
+
     free(tasks);
 
     return ret_value;

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -102,26 +102,23 @@ typedef struct {
     int      fd;
 } info_for_thread_t;
 
+/* Forward declaration of Bypass_task_t */
+typedef struct Bypass_task_t Bypass_task_t;
+
+typedef struct Bypass_task_t {
+    int     file_index; /* Index of the file containing the dset to read from in the file_stuff array */
+    haddr_t addr;       /* Location in filesystem file to read from */
+    size_t  size;
+    void   *vec_buf;    /* User buffer to populate */
+    Bypass_task_t *next;
+} Bypass_task_t;
+
 typedef struct {
-    int      thread_id;
-    int      fd;            /* Remove this field and use file_indices */
-    uint32_t step;
-    int      *file_indices;
-    haddr_t  *addrs;
-    size_t   *sizes;
-    void     **vec_bufs;
-
-    int        file_indices_local[LOCAL_VECTOR_LEN];
-    haddr_t    addrs_local[LOCAL_VECTOR_LEN];
-    size_t     sizes_local[LOCAL_VECTOR_LEN];
-    void       *vec_bufs_local[LOCAL_VECTOR_LEN];
-
-    size_t     vec_arr_nalloc;
-    size_t     vec_arr_nused;
-    bool       free_memory;
-
     bool       *thread_is_active; /* Array of active status for each tpool thread */
 } info_for_tpool_t;
+
+static Bypass_task_t *bypass_queue_head_g;
+static Bypass_task_t *bypass_queue_tail_g;
 
 static info_t *info_stuff;
 static int info_count = 0;


### PR DESCRIPTION
Re-implement md_for_threads as a proper queue of task objects, with push/pop methods. The primary benefit of this is that memory use will no longer grow without limit, as each thread frees the task memory after the task is complete.