### PR TITLE
Bypass VOL: Fix segfault due to sel buffer overrun

### DIFF
--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2641,6 +2641,12 @@ H5VL_bypass_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t 
             }
         }
 
+        if (selection_info.my_file_index < 0) {
+            fprintf(stderr, "failed to find file in file_stuff\n");
+            ret_value = -1;
+            goto done;
+        }
+
         if ((num_ext_files = H5Pget_external_count(bypass_dset->dcpl_id)) < 0) {
             fprintf(stderr, "failed to get external file count\n");
             ret_value = -1;

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -84,8 +84,8 @@ typedef struct {
 typedef struct {
     size_t  counter;
 
-    char    file_name[64];
-    char    dset_name[64];
+    char    file_name[BYPASS_NAME_SIZE_LONG];
+    char    dset_name[BYPASS_NAME_SIZE_LONG];
 
     int     my_file_index;        /* The index of the FILE_T structure for this file */ 
     hid_t   file_space_id;


### PR DESCRIPTION
If a file and/or dataset has a long name (>64 chars), copying it to `sel_info_t` could invalidate other data stored in that struct, leading to segfaults.