### PR TITLE
Implemented task queue

### DIFF
--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -102,26 +102,23 @@ typedef struct {
     int      fd;
 } info_for_thread_t;
 
+/* Forward declaration of Bypass_task_t */
+typedef struct Bypass_task_t Bypass_task_t;
+
+typedef struct Bypass_task_t {
+    int     file_index; /* Index of the file containing the dset to read from in the file_stuff array */
+    haddr_t addr;       /* Location in filesystem file to read from */
+    size_t  size;
+    void   *vec_buf;    /* User buffer to populate */
+    Bypass_task_t *next;
+} Bypass_task_t;
+
 typedef struct {
-    int      thread_id;
-    int      fd;            /* Remove this field and use file_indices */
-    uint32_t step;
-    int      *file_indices;
-    haddr_t  *addrs;
-    size_t   *sizes;
-    void     **vec_bufs;
-
-    int        file_indices_local[LOCAL_VECTOR_LEN];
-    haddr_t    addrs_local[LOCAL_VECTOR_LEN];
-    size_t     sizes_local[LOCAL_VECTOR_LEN];
-    void       *vec_bufs_local[LOCAL_VECTOR_LEN];
-
-    size_t     vec_arr_nalloc;
-    size_t     vec_arr_nused;
-    bool       free_memory;
-
     bool       *thread_is_active; /* Array of active status for each tpool thread */
 } info_for_tpool_t;
+
+static Bypass_task_t *bypass_queue_head_g;
+static Bypass_task_t *bypass_queue_tail_g;
 
 static info_t *info_stuff;
 static int info_count = 0;


### PR DESCRIPTION
Transferred Matt's PR (#32): Re-implement md_for_threads as a proper queue of task objects, with push/pop methods. The primary benefit of this is that memory use will no longer grow without limit, as each thread frees the task memory after the task is complete.