### PR TITLE
Simplify H5Dread() blocking

### DIFF
--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2013,10 +2013,6 @@ done:
         }
     }
 
-    /* pthread_mutex_lock(&mutex_local);
-    md_for_thread.thread_is_active[thread_id] = false;
-    pthread_mutex_unlock(&mutex_local); */
-
     free(tasks);
 
     return ret_value;

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -48,9 +48,10 @@ pthread_cond_t  continue_local;
 int  nthreads_tpool       = NUM_LOCAL_THREADS;
 int  nsteps_tpool         = THREAD_STEP;
 int  info_pointer         = 0;
-int  thread_task_count    = 0;
-bool thread_task_finished = false;                   /* Flag for H5Dread to notify the thread pool that it finished putting tasks in the queue */
-bool thread_loop_finish   = false;
+int  tasks_in_queue    = 0;
+int  tasks_unfinished  = 0;
+bool all_tasks_enqueued = false;                   /* Flag for H5Dread to notify the thread pool that it finished putting tasks in the queue */
+
 bool stop_tpool           = false;                   /* Flag to tell the thread pool to terminate, turned on in H5VL_bypass_term */
 pthread_t th[NTHREADS_MAX];
 


### PR DESCRIPTION
This commit is based on Matt's PR #40 (Simplify H5Dread() blocking): Rename thread_task_count -> tasks_in_queue;
Instead of the 'thread active status', block the main thread until the number of unfinished tasks is zero.