### PR TITLE
Bug fix: when the native library is used for reading data, the global lock didn't get released

### DIFF
--- a/vol_bypass/H5VLbypass.c
+++ b/vol_bypass/H5VLbypass.c
@@ -2658,7 +2658,6 @@ H5VL_bypass_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t 
         ret_value = -1;
         goto done;
     }
-
     //fprintf(stderr, "In %s of %s at line %d: has_global = %d\n", __func__, __FILE__, __LINE__, has_global);
 
     /* Grab the global lock of the HDF5 library */
@@ -2755,6 +2754,14 @@ H5VL_bypass_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t 
             || file_space_id[j] == H5S_BLOCK || mem_space_id[j] == H5S_PLIST || file_space_id[j] == H5S_PLIST;
 
         if (read_use_native) {
+            /* Let go the global lock of the HDF5 library */
+	    if (acquired_global && H5TSmutex_release(&lock_count) != 0) {
+		fprintf(stderr, "In %s of %s at line %d: H5TSmutex_release failed\n", __func__, __FILE__, __LINE__);
+		ret_value = -1;
+		goto done;
+	    }
+
+	    acquired_global = false;
 
             /* Populate the array of under objects */
             under_vol_id = ((H5VL_bypass_t *)(dset[0]))->under_vol_id;
@@ -2886,8 +2893,6 @@ H5VL_bypass_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t 
 	    }
 
 	    acquired_global = false;
-
-            //printf("%s: %d\n", __func__, __LINE__);
 
             /* Each thread reads from its own task queue if 'BYPASS_VOL_NO_TPOOL' environment variable is set */
             if (no_tpool) {

--- a/vol_bypass/H5VLbypass_private.h
+++ b/vol_bypass/H5VLbypass_private.h
@@ -124,13 +124,12 @@ typedef struct H5VL_bypass_t {
 typedef struct Bypass_task_t Bypass_task_t;
 
 typedef struct Bypass_task_t {
-    int            file_index; /* Ray: Remove it.  Index of the file containing the dset to read from in the file_stuff array */
     H5VL_bypass_t *file;
-    haddr_t        addr;       /* Location in filesystem file to read from */
+    haddr_t        addr;                 /* Location of filesystem file to read from or write to*/
     size_t         size;
-    void          *vec_buf;    /* User buffer to populate */
-    atomic_int    *task_count_ptr;
-    pthread_cond_t *local_condition_ptr;
+    void          *vec_buf;              /* User buffer */
+    atomic_int    *task_count_ptr;       /* This pointer keeps track of the number of tasks in the queue for the current thread */
+    pthread_cond_t *local_condition_ptr; /* This pointer passes the local condition variable for the current thread to the thread pool */
     Bypass_task_t *next;
 } Bypass_task_t;
 

--- a/vol_bypass/test/posix_read_mthread.c
+++ b/vol_bypass/test/posix_read_mthread.c
@@ -347,8 +347,6 @@ launch_single_file_single_dset_read(void)
 		c_info[i].data = data_out;
 		c_info[i].fp = fp;
 
-		//printf("c_info[%d].file_info_entry_num = %d, file_info_num_allocated = %d\n", i, c_info[i].file_info_entry_num, file_info_num_allocated);
-
 		pthread_create(&threads[i], NULL, read_partial_dset_with_multiple_threads, &c_info[i]);
             }
 


### PR DESCRIPTION
Corrected it.